### PR TITLE
deprecating `find_opening` 

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -9,3 +9,4 @@ dependencies:
 - sphinx
 - sphinx-argparse
 - sphinx-mdinclude
+- typing_extensions >=4.5.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(),
     use_scm_version={"write_to": f"{project_name}/_version.py"},
     setup_requires=["setuptools_scm"],
-    install_requires=["click", "numpy"],
+    install_requires=["click", "numpy", "typing_extensions>=4.5.0"],
     entry_points={
         "console_scripts": [
             f"texplain = {project_name}:_texplain_cli",

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -12,6 +12,7 @@ from shutil import copyfile
 import numpy as np
 from numpy.typing import ArrayLike
 from numpy.typing import NDArray
+from typing_extensions import deprecated
 
 from ._version import version  # noqa: F401
 from ._version import version_tuple  # noqa: F401
@@ -39,6 +40,7 @@ class PlaceholderType(enum.Enum):
     newif_command = enum.auto()
 
 
+@deprecated("Use regex directly")
 def find_opening(
     text: str,
     opening: str,
@@ -73,8 +75,8 @@ def find_commented(text: str) -> list[list[int]]:
     :return: List of of indices of the beginning and end of the comments.
     """
 
-    comments = np.array(find_opening(text, "%", ignore_escaped=True))
-    newlines = np.array(find_opening(text, "\n", ignore_escaped=False) + [len(text)])
+    comments = np.array([i.span()[0] for i in re.finditer(r"(?<!\\)(%)", text)])
+    newlines = np.array([i.span()[0] for i in re.finditer(r"\n", text)] + [len(text)])
 
     ret = []
 


### PR DESCRIPTION
(pre-use PEP 702, but `@deprecated` and `typing_extensions` can be removed at any time)