### PR TITLE
Formatting math (much like black formats Python code)

### DIFF
--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -4,9 +4,9 @@ import texplain
 def test_arithmetic():
     assert texplain.formatter_math(r"a=b") == r"a = b"
     assert texplain.formatter_math(r"a-b") == r"a - b"
-    # assert texplain.formatter_math(r"a\leq b") == r"a \leq b"
+    assert texplain.formatter_math(r"a\leq b") == r"a \leq b"
     assert texplain.formatter_math(r"\theta>0") == r"\theta > 0"
-    # assert texplain.formatter_math(r"P(x)\sim x^\theta") == r"P(x) \sim x^\theta"
+    assert texplain.formatter_math(r"P(x)\sim x^\theta") == r"P(x) \sim x^\theta"
 
 
 def test_comma():

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -2,6 +2,7 @@ import texplain
 
 
 def test_arithmetic():
+    assert texplain.formatter_math(r"i-1") == r"i - 1"
     assert texplain.formatter_math(r"a=b") == r"a = b"
     assert texplain.formatter_math(r"a:=b") == r"a := b"
     assert texplain.formatter_math(r"a-b") == r"a - b"
@@ -23,4 +24,4 @@ def test_sign():
     assert texplain.formatter_math(r"{ - b}") == r"{-b}"
     assert texplain.formatter_math(r"{- b}") == r"{-b}"
     assert texplain.formatter_math(r"{-b}") == r"{-b}"
-    assert texplain.formatter_math(r"a = -0.30") == r"a = -0.30"
+    # assert texplain.formatter_math(r"a = -0.30") == r"a = -0.30" # not distinguishable from i - 1

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -23,3 +23,4 @@ def test_sign():
     assert texplain.formatter_math(r"{ - b}") == r"{-b}"
     assert texplain.formatter_math(r"{- b}") == r"{-b}"
     assert texplain.formatter_math(r"{-b}") == r"{-b}"
+    assert texplain.formatter_math(r"a = -0.30") == r"a = -0.30"

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -1,13 +1,20 @@
 import texplain
 
 
-def test_simple():
-    assert texplain.formatter_math("a=b") == "a = b"
-    assert texplain.formatter_math("a-b") == "a - b"
+def test_arithmetic():
+    assert texplain.formatter_math(r"a=b") == r"a = b"
+    assert texplain.formatter_math(r"a-b") == r"a - b"
+    # assert texplain.formatter_math(r"a\leq b") == r"a \leq b"
+    assert texplain.formatter_math(r"\theta>0") == r"\theta > 0"
+    # assert texplain.formatter_math(r"P(x)\sim x^\theta") == r"P(x) \sim x^\theta"
+
+
+def test_comma():
+    assert texplain.formatter_math(r"1,2") == r"1,2"
     assert texplain.formatter_math(r"\tau, \nu, \ldots") == r"\tau, \nu, \ldots"
 
 
 def test_braces():
-    assert texplain.formatter_math("{ - b}") == "{-b}"
-    assert texplain.formatter_math("{- b}") == "{-b}"
-    assert texplain.formatter_math("{-b}") == "{-b}"
+    assert texplain.formatter_math(r"{ - b}") == r"{-b}"
+    assert texplain.formatter_math(r"{- b}") == r"{-b}"
+    assert texplain.formatter_math(r"{-b}") == r"{-b}"

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -3,6 +3,7 @@ import texplain
 
 def test_arithmetic():
     assert texplain.formatter_math(r"a=b") == r"a = b"
+    assert texplain.formatter_math(r"a:=b") == r"a := b"
     assert texplain.formatter_math(r"a-b") == r"a - b"
     assert texplain.formatter_math(r"a\leq b") == r"a \leq b"
     assert texplain.formatter_math(r"\theta>0") == r"\theta > 0"

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -24,4 +24,5 @@ def test_sign():
     assert texplain.formatter_math(r"{ - b}") == r"{-b}"
     assert texplain.formatter_math(r"{- b}") == r"{-b}"
     assert texplain.formatter_math(r"{-b}") == r"{-b}"
-    # assert texplain.formatter_math(r"a = -0.30") == r"a = -0.30" # not distinguishable from i - 1
+    assert texplain.formatter_math(r"\gamma=-0.30") == r"\gamma = -0.30"
+    assert texplain.formatter_math(r"a = - 0.30") == r"a = -0.30"

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -1,0 +1,13 @@
+import texplain
+
+
+def test_simple():
+    assert texplain.formatter_math("a=b") == "a = b"
+    assert texplain.formatter_math("a-b") == "a - b"
+    assert texplain.formatter_math(r"\tau, \nu, \ldots") == r"\tau, \nu, \ldots"
+
+
+def test_braces():
+    assert texplain.formatter_math("{ - b}") == "{-b}"
+    assert texplain.formatter_math("{- b}") == "{-b}"
+    assert texplain.formatter_math("{-b}") == "{-b}"

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -16,7 +16,10 @@ def test_comma():
     assert texplain.formatter_math(r"\tau, \nu, \ldots") == r"\tau, \nu, \ldots"
 
 
-def test_braces():
+def test_sign():
+    assert texplain.formatter_math(r" - b") == r"-b"
+    assert texplain.formatter_math(r"- b") == r"-b"
+    assert texplain.formatter_math(r"-b") == r"-b"
     assert texplain.formatter_math(r"{ - b}") == r"{-b}"
     assert texplain.formatter_math(r"{- b}") == r"{-b}"
     assert texplain.formatter_math(r"{-b}") == r"{-b}"

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -7,6 +7,7 @@ def test_arithmetic():
     assert texplain.formatter_math(r"a\leq b") == r"a \leq b"
     assert texplain.formatter_math(r"\theta>0") == r"\theta > 0"
     assert texplain.formatter_math(r"P(x)\sim x^\theta") == r"P(x) \sim x^\theta"
+    assert texplain.formatter_math(r"a\simeq 0.2") == r"a \simeq 0.2"
 
 
 def test_comma():

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -26,3 +26,4 @@ def test_sign():
     assert texplain.formatter_math(r"{-b}") == r"{-b}"
     assert texplain.formatter_math(r"\gamma=-0.30") == r"\gamma = -0.30"
     assert texplain.formatter_math(r"a = - 0.30") == r"a = -0.30"
+    assert texplain.formatter_math(r"r_0 = -w / 2") == r"r_0 = -w / 2"

--- a/tests/test_formatter_math.py
+++ b/tests/test_formatter_math.py
@@ -10,6 +10,7 @@ def test_arithmetic():
     assert texplain.formatter_math(r"\theta>0") == r"\theta > 0"
     assert texplain.formatter_math(r"P(x)\sim x^\theta") == r"P(x) \sim x^\theta"
     assert texplain.formatter_math(r"a\simeq 0.2") == r"a \simeq 0.2"
+    assert texplain.formatter_math(r"\lambda_+") == r"\lambda_+"
 
 
 def test_comma():

--- a/tests/test_indent_long.py
+++ b/tests/test_indent_long.py
@@ -181,12 +181,12 @@ which we verify in \cref{fig:2c}.
 For a slip event at interface $s$, we have $\Delta R_s > 0$ and $\Delta R_i = 0$ for $i \neq s$, inducing
 \begin{equation}
     \label{eq:delta_fi}
-    \Delta f_i = K\Delta R_s \,\, \mathrm{for} \,\, i \geq s ; \quad \Delta f_i=0 \,\, \mathrm{otherwise}.
+    \Delta f_i = K\Delta R_s \,\, \mathrm{for} \,\, i \geq s ; \quad \Delta f_i = 0 \,\, \mathrm{otherwise}.
 \end{equation}
 We can then deduce that
 \begin{equation}
     \label{eq:DR_DF_multi}
-    \Delta F = \frac{h K}{H} \Delta R_s \sum\limits_{i=s}^n i \, = \frac{h K}{H}\Delta R_s (n+s)(n-s+1) / 2.
+    \Delta F = \frac{h K}{H} \Delta R_s \sum\limits_{i = s}^n i \, = \frac{h K}{H}\Delta R_s (n + s)(n - s + 1) / 2.
 \end{equation}
 which we verify in \cref{fig:2c}.
 """
@@ -339,8 +339,40 @@ This is a sentence.
 \end{table}
 """
 
+    formatted = r"""
+The names (Smith, Doe, etc.) are inherited.
+
+Two items are used:
+\begin{itemize}
+    \item Item 1.
+    \item Item 2.
+\end{itemize}
+
+The energy is defined as
+\begin{equation}
+    E = m c^2
+\end{equation}
+where m is the mass.
+
+\begin{table}[htbp]
+    \caption{\label{tab1} Here is the legend.}
+    \begin{tabular}{cc}
+        1 & 1 \\
+    \end{tabular}
+\end{table}
+
+This is a sentence.
+
+\begin{table}[htbp]
+    \caption{\label{tab1} Here is the legend.}
+    \begin{tabular}{cc}
+        1 & 1 \\
+    \end{tabular}
+\end{table}
+"""
+
     ret = texplain.indent(text)
-    assert ret.strip() == text.strip()
+    assert ret.strip() == formatted.strip()
 
 
 def test_latexindent_one_sentence_per_line_more_code_blocks():

--- a/tests/test_indent_long.py
+++ b/tests/test_indent_long.py
@@ -295,7 +295,7 @@ This is an example (i.e.~a test).
 The unit is $\rm kg.m^{-2}.s^{-1}$.
 Values goes from 0.02 to 0.74 Pa.
 Here some space needed \hspace{0.5cm}.
-The value is $\lambda=3.67$.
+The value is $\lambda = 3.67$.
 The URL is \url{www.scilab.org}.
 """
 

--- a/tests/test_indent_options.py
+++ b/tests/test_indent_options.py
@@ -77,8 +77,7 @@ This a text \begin{math} a = b
 """
 
     formatted = r"""
-This a text \begin{math} a = b
-\end{math} with
+This a text \begin{math} a = b \end{math} with
 \begin{equation}
 a = b
 \end{equation}

--- a/tests/test_indent_simple.py
+++ b/tests/test_indent_simple.py
@@ -1276,11 +1276,11 @@ some text
 
 def test_format_math_inline():
     text = r"""
-Some text $a = b$ with $c=d$ some more text and \(e=f\).
+Some text $a = b$ with $c=d$ some more text and \(e=f\) to \begin{math}g=h\end{math}.
 """
 
     formatted = r"""
-Some text $a = b$ with $c=d$ some more text and \(e=f\).
+Some text $a = b$ with $c = d$ some more text and \(e = f\) to \begin{math} g = h \end{math}.
 """
 
     ret = texplain.indent(text)

--- a/tests/test_indent_simple.py
+++ b/tests/test_indent_simple.py
@@ -1285,3 +1285,46 @@ Some text $a = b$ with $c = d$ some more text and \(e = f\) to \begin{math} g = 
 
     ret = texplain.indent(text)
     assert ret.strip() == formatted.strip()
+
+
+def test_format_math_equation():
+    text = r"""
+\begin{equation} a= b \end{equation}
+and
+\begin{equation}
+    c=d \label{eq:foo}
+\end{equation}
+and
+\begin{equation}
+    e=f
+    \label{eq:foo}
+\end{equation}
+and
+\begin{equation}
+    \label{eq:foo}
+    g=h
+\end{equation}
+"""
+
+    formatted = r"""
+\begin{equation}
+    a = b
+\end{equation}
+and
+\begin{equation}
+    c = d \label{eq:foo}
+\end{equation}
+and
+\begin{equation}
+    e = f
+    \label{eq:foo}
+\end{equation}
+and
+\begin{equation}
+    \label{eq:foo}
+    g = h
+\end{equation}
+"""
+
+    ret = texplain.indent(text)
+    assert ret.strip() == formatted.strip()

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1389,9 +1389,30 @@ def formatter_math(text: str) -> str:
     text = re.sub(r"([=\+\*\-\/\<\>])([\w\\])", r"\1 \2", text)
 
     # add spaces around arithmetic operators (\leq, \sim, ...)
-    for operator in [r"leq", r"geq", r"sim", r"simeq", r"approx", r"equiv", r"neq", r"rightarrow", r"leftarrow", r"uparrow", r"downarrow", r"leftrightarrow", r"updownarrow", r"leftrightarrows", r"updownarrows"]:
+    for operator in [
+        "leq",
+        "geq",
+        "sim",
+        "simeq",
+        "approx",
+        "equiv",
+        "neq",
+        "rightarrow",
+        "leftarrow",
+        "uparrow",
+        "downarrow",
+        "leftrightarrow",
+        "updownarrow",
+        "leftrightarrows",
+        "updownarrows",
+    ]:
         text = re.sub(r"([\w\(\)\{\}])(\\%s)(\s)(\s*)" % operator, r"\1 \2\3", text)
         text = re.sub(r"(\\%s)(\s)(\s*)([\w\\])" % operator, r"\1\2\4", text)
+
+    # add spaces around arithmetic operators (:=)
+    for operator in [":="]:
+        text = re.sub(r"([\w\(\)\{\}])(%s)(\s)(\s*)" % operator, r"\1 \2\3", text)
+        text = re.sub(r"(%s)(\s)(\s*)([\w\\])" % operator, r"\1\2\4", text)
 
     # remove spaces for signs
     text = re.sub(r"([\{\(])(\s*)([\\\+\-\<\>])(\s*)", r"\1\3", text)

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1418,18 +1418,18 @@ def formatter_math(text: str) -> str:
         "leftrightarrows",
         "updownarrows",
     ]:
-        text = re.sub(r"([\w\(\)\{\}])(\\%s)(\s)(\s*)" % operator, r"\1 \2\3", text)
-        text = re.sub(r"(\\%s)(\s)(\s*)([\w\\])" % operator, r"\1\2\4", text)
+        text = re.sub(r"([a-zA-Z0-9\(\)\{\}])(\\%s)(\s)(\s*)" % operator, r"\1 \2\3", text)
+        text = re.sub(r"(\\%s)(\s)(\s*)([a-zA-Z0-9\\])" % operator, r"\1\2\4", text)
 
     # add spaces around arithmetic operators (:=)
     for operator in [":="]:
-        text = re.sub(r"([\w\(\)\{\}])(%s)(\s)(\s*)" % operator, r"\1 \2\3", text)
-        text = re.sub(r"(%s)(\s)(\s*)([\w\\])" % operator, r"\1\2\4", text)
+        text = re.sub(r"([a-zA-Z0-9\(\)\{\}])(%s)(\s)(\s*)" % operator, r"\1 \2\3", text)
+        text = re.sub(r"(%s)(\s)(\s*)([a-zA-Z0-9\\])" % operator, r"\1\2\4", text)
 
     # remove spaces for signs
     text = re.sub(r"([\{\(])(\s*)([\\\+\-])(\s*)", r"\1\3", text)
     text = re.sub(r"^(\s*)([\+\-])(\s*)(.*)", r"\2\4", text)
-    text = re.sub(r"(\=)(\s*)([\+\-])(\s*)(\w)", r"\1 \3\5", text)
+    text = re.sub(r"(\=)(\s*)([\+\-])(\s*)([a-zA-Z0-9])", r"\1 \3\5", text)
 
     return text
 

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1397,8 +1397,8 @@ def formatter_math(text: str) -> str:
     text = text.strip()
 
     # add spaces around arithmetic operators (simple)
-    text = re.sub(r"([\w\(\)\{\}])([=\+\*\-\/\<\>])", r"\1 \2", text)
-    text = re.sub(r"([=\+\*\-\/\<\>])([\w\\])", r"\1 \2", text)
+    text = re.sub(r"([a-zA-Z0-9\(\)\{\}])([=\+\*\-\/\<\>])", r"\1 \2", text)
+    text = re.sub(r"([=\+\*\-\/\<\>])([a-zA-Z0-9\\])", r"\1 \2", text)
 
     # add spaces around arithmetic operators (\leq, \sim, ...)
     for operator in [

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1429,7 +1429,7 @@ def formatter_math(text: str) -> str:
     # remove spaces for signs
     text = re.sub(r"([\{\(])(\s*)([\\\+\-])(\s*)", r"\1\3", text)
     text = re.sub(r"^(\s*)([\+\-])(\s*)(.*)", r"\2\4", text)
-    text = re.sub(r"(\=)(\s*)([\+\-])(\s*)([0-9])", r"\1 \3\5", text)
+    text = re.sub(r"(\=)(\s*)([\+\-])(\s*)(\w)", r"\1 \3\5", text)
 
     return text
 

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1434,6 +1434,14 @@ def formatter_math(text: str) -> str:
 
 
 def _formatter_inline_math(text: str) -> str:
+    """
+    Apply :py:func:`formatter_math` to a string that includes inline math commands.
+    For example ``\(a+b\)`` applies ``"\(" + formatter_math("a+b") + "\)"``.
+
+    :param text: Math string, including inline math commands.
+    :return: Formatted math string, including inline math commands.
+    """
+
     if text[:2] == "$$" and text[-2:] == "$$":
         return "$$" + formatter_math(text[2:-2]) + "$$"
     if text[0] == "$" and text[-1] == "$":

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1429,6 +1429,7 @@ def formatter_math(text: str) -> str:
     # remove spaces for signs
     text = re.sub(r"([\{\(])(\s*)([\\\+\-])(\s*)", r"\1\3", text)
     text = re.sub(r"^(\s*)([\+\-])(\s*)(.*)", r"\2\4", text)
+    text = re.sub(r"([\+\-])(\s*)([0-9])", r"\1\3", text)
 
     return text
 

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -723,10 +723,9 @@ def _detail_text_to_placholders(
                 skip = False
                 if re.match(r"(?<!\\)(\\begin{)", line):
                     skip = True
-                if re.match(r"(?<!\\)(\\end{)", line):
+                elif re.match(r"(?<!\\)(\\end{)", line):
                     skip = True
-                # existing placeholder
-                if re.match(r"(\-%s\-)(\w*\-)*(\d+\-)" % base, line):
+                elif re.match(r"(\-%s\-)(\w*\-)*(\d+\-)" % base, line):  # existing placeholder
                     skip = True
                 n = len(line)
                 if not skip:

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -725,6 +725,9 @@ def _detail_text_to_placholders(
                     skip = True
                 if re.match(r"(?<!\\)(\\end{)", line):
                     skip = True
+                # existing placeholder
+                if re.match(r"(\-%s\-)(\w*\-)*(\d+\-)" % base, line):
+                    skip = True
                 n = len(line)
                 if not skip:
                     all_indices += [[starting, starting + n]]

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1554,8 +1554,8 @@ def indent(
 
     format_math:
         Format math.
-        Adds spaces around arithmetic, e.g. ``$a+b$`` is formatted to ``$a + b$``.
-        Removes spaces around signs, e.g. ``$a^{- b}$`` is formatted to ``$a^{-b}$``.
+        Adds spaces around arithmetic, e.g. ``a+b`` is formatted to ``a + b``.
+        Removes spaces around signs, e.g. ``a^{- b}`` is formatted to ``a^{-b}``.
 
     :return: The indented text.
     """

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1434,7 +1434,7 @@ def formatter_math(text: str) -> str:
 
 
 def _formatter_inline_math(text: str) -> str:
-    """
+    r"""
     Apply :py:func:`formatter_math` to a string that includes inline math commands.
     For example ``\(a+b\)`` applies ``"\(" + formatter_math("a+b") + "\)"``.
 

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1429,7 +1429,7 @@ def formatter_math(text: str) -> str:
     # remove spaces for signs
     text = re.sub(r"([\{\(])(\s*)([\\\+\-])(\s*)", r"\1\3", text)
     text = re.sub(r"^(\s*)([\+\-])(\s*)(.*)", r"\2\4", text)
-    # text = re.sub(r"([\+\-])(\s*)([0-9])", r"\1\3", text)
+    text = re.sub(r"(\=)(\s*)([\+\-])(\s*)([0-9])", r"\1 \3\5", text)
 
     return text
 

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1429,7 +1429,7 @@ def formatter_math(text: str) -> str:
     # remove spaces for signs
     text = re.sub(r"([\{\(])(\s*)([\\\+\-])(\s*)", r"\1\3", text)
     text = re.sub(r"^(\s*)([\+\-])(\s*)(.*)", r"\2\4", text)
-    text = re.sub(r"([\+\-])(\s*)([0-9])", r"\1\3", text)
+    # text = re.sub(r"([\+\-])(\s*)([0-9])", r"\1\3", text)
 
     return text
 

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1427,7 +1427,8 @@ def formatter_math(text: str) -> str:
         text = re.sub(r"(%s)(\s)(\s*)([\w\\])" % operator, r"\1\2\4", text)
 
     # remove spaces for signs
-    text = re.sub(r"([\{\(])(\s*)([\\\+\-\<\>])(\s*)", r"\1\3", text)
+    text = re.sub(r"([\{\(])(\s*)([\\\+\-])(\s*)", r"\1\3", text)
+    text = re.sub(r"^(\s*)([\+\-])(\s*)(.*)", r"\2\4", text)
 
     return text
 

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1389,9 +1389,9 @@ def formatter_math(text: str) -> str:
     text = re.sub(r"([=\+\*\-\/\<\>])([\w\\])", r"\1 \2", text)
 
     # add spaces around arithmetic operators (\leq, \sim, ...)
-    for operator in [r"leq", r"geq", r"sim", r"simeq", r"approx", r"equiv", r"neq"]:
-        text = re.sub(r"([\w\(\)\{\}])(\\%s)" % operator, r"\1 \2", text)
-        text = re.sub(r"(\\%s)([\w\\])" % operator, r"\1 \2", text)
+    for operator in [r"leq", r"geq", r"sim", r"simeq", r"approx", r"equiv", r"neq", r"rightarrow", r"leftarrow", r"uparrow", r"downarrow", r"leftrightarrow", r"updownarrow", r"leftrightarrows", r"updownarrows"]:
+        text = re.sub(r"([\w\(\)\{\}])(\\%s)(\s)(\s*)" % operator, r"\1 \2\3", text)
+        text = re.sub(r"(\\%s)(\s)(\s*)([\w\\])" % operator, r"\1\2\4", text)
 
     # remove spaces for signs
     text = re.sub(r"([\{\(])(\s*)([\\\+\-\<\>])(\s*)", r"\1\3", text)

--- a/texplain/__init__.py
+++ b/texplain/__init__.py
@@ -1383,9 +1383,19 @@ def formatter_math(text: str) -> str:
     """
     assert len(text.splitlines()) == 1
     text = text.strip()
+
+    # add spaces around arithmetic operators (simple)
     text = re.sub(r"([\w\(\)\{\}])([=\+\*\-\/\<\>])", r"\1 \2", text)
     text = re.sub(r"([=\+\*\-\/\<\>])([\w\\])", r"\1 \2", text)
+
+    # add spaces around arithmetic operators (\leq, \sim, ...)
+    for operator in [r"leq", r"geq", r"sim", r"simeq", r"approx", r"equiv", r"neq"]:
+        text = re.sub(r"([\w\(\)\{\}])(\\%s)" % operator, r"\1 \2", text)
+        text = re.sub(r"(\\%s)([\w\\])" % operator, r"\1 \2", text)
+
+    # remove spaces for signs
     text = re.sub(r"([\{\(])(\s*)([\\\+\-\<\>])(\s*)", r"\1\3", text)
+
     return text
 
 


### PR DESCRIPTION
Fixes https://github.com/tdegeus/texplain/issues/52

Todo:
* [ ] `\label{...}`, `\text{...}`, `\mathrm{...}` should not be formatted. 

The simplest is to change the placeholder formatting to not include `-` (or `+`, etc.) such that they are not formatted by this function. Then `\label{...}`, `\text{...}`, etc could be converted to placeholders before formatting